### PR TITLE
Fixed registration link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ documentation, the security related bugs need a special handling.*
 If you find a problem, please report it either using
 [Bugzilla](https://bugzilla.suse.com/enter_bug.cgi?format=guided&product=openSUSE+Tumbleweed&component=YaST2)
 or [GitHub issues](../../issues). (For Bugzilla, use the [simplified
-registration](https://secure-www.novell.com/selfreg/jsp/createSimpleAccount.jsp)
+registration](https://www.suse.com/selfreg/jsp/createSimpleAccount.jsp)
 if you don't have an account yet.)
 
 When creating a bug report, please follow our [bug reporting


### PR DESCRIPTION
Use SUSE registration link 

- https://trello.com/c/6HNCLXx9/1780-0-remove-a-novell-microfocus-link-from-all-contributingmd-files