### PR TITLE
Added global shared pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+
+## Problem
+
+*Short description of the original problem.*
+
+- *Bugzilla link*
+- *openQA link*
+- *Links to other related pull requests*
+
+
+## Solution
+
+*Short description of the fix.*
+
+
+## Testing
+
+- *Added a new unit test*
+- *Tested manually*
+
+
+## Screenshots
+
+*If the fix affects the UI attach some screenshots here.*
+


### PR DESCRIPTION
- Let's have a global shared PR template
- The file has been just copied from the [`yast2-storage-ng` template](https://github.com/yast/yast-storage-ng/blob/2503c57444ae7f7f8c96a9e72ec2a0771c770beb/.github/pull_request_template.md), we can remove it after merging this
- This should work as a reminder to write good descriptions for pull requests in all YaST repositories
- This is just the default, it can be overridden by a file in each GitHub YaST repository if there is a need for a different content
- See the [GitHub documentation](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for more details